### PR TITLE
Suggestion to move the readSeeker out and remove the mutex

### DIFF
--- a/cmd/mp4ff-info/main.go
+++ b/cmd/mp4ff-info/main.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalln(err)
 	}
 	defer ifd.Close()
-	parsedMp4, err := mp4.DecodeFileLazily(ifd)
+	parsedMp4, err := mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -161,9 +161,6 @@ LoopBoxes:
 					return nil, fmt.Errorf("Does not support %v between moof and mdat", lastBoxType)
 				}
 			}
-			if f.fileDecMode == DecModeLazyMdat {
-				box.(*MdatBox).setReadSeeker(rs)
-			}
 		}
 		f.AddChild(box, boxStartPos)
 		lastBoxType = boxType

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -23,9 +23,6 @@ func TestDecodeFileWithLazyMdatOption(t *testing.T) {
 			if frag.Mdat.decLazyDataSize == 0 {
 				t.Error("decLazyDataSize is expected to be greater than 0")
 			}
-			if frag.Mdat.readSeeker == nil {
-				t.Error("Mdat readSeeker is expected to be non-nil")
-			}
 			if frag.Mdat.Data != nil {
 				t.Error("Mdat Data is expected to be nil")
 			}
@@ -51,9 +48,6 @@ func TestDecodeFileWithNoLazyMdatOption(t *testing.T) {
 		for _, frag := range seg.Fragments {
 			if frag.Mdat.decLazyDataSize != 0 {
 				t.Error("decLazyDataSize is expected to be 0")
-			}
-			if frag.Mdat.readSeeker != nil {
-				t.Error("Mdat readSeeker is expected to be nil")
 			}
 			if frag.Mdat.Data == nil || len(frag.Mdat.Data) == 0 {
 				t.Error("Mdat Data is expected to be non-nil")

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"sync"
 )
 
 // MdatBox - Media Data Box (mdat)
@@ -15,10 +14,6 @@ type MdatBox struct {
 	Data            []byte
 	decLazyDataSize uint64
 	LargeSize       bool
-
-	// the following fields are only used in lazy mdat decode mode
-	mu         *sync.Mutex
-	readSeeker io.ReadSeeker
 }
 
 const maxNormalPayloadSize = (1 << 32) - 1 - 8
@@ -30,14 +25,14 @@ func DecodeMdat(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 		return nil, err
 	}
 	largeSize := hdr.hdrlen > boxHeaderSize
-	return &MdatBox{startPos, data, 0, largeSize, nil, nil}, nil
+	return &MdatBox{startPos, data, 0, largeSize}, nil
 }
 
 // DecodeMdatLazily - box-specific decode but Data is not in memory
 func DecodeMdatLazily(hdr *boxHeader, startPos uint64) (Box, error) {
 	largeSize := hdr.hdrlen > boxHeaderSize
 	decLazyDataSize := hdr.size - uint64(hdr.hdrlen)
-	return &MdatBox{startPos, nil, decLazyDataSize, largeSize, &sync.Mutex{}, nil}, nil
+	return &MdatBox{startPos, nil, decLazyDataSize, largeSize}, nil
 }
 
 // Type - return box type
@@ -93,32 +88,23 @@ func (m *MdatBox) PayloadAbsoluteOffset() uint64 {
 	return m.StartPos + m.HeaderSize()
 }
 
-// setReadSeeker - set readseeker to read Mdat data.
-// When a file is decoded lazily, the Mdat Data byte slice is nil
-// and this readseeker is to read data whenever the data is needed.
-func (m *MdatBox) setReadSeeker(rs io.ReadSeeker) {
-	m.readSeeker = rs
-}
-
 // ReadData reads Mdat data specified by the start and size.
 // Input argument start is the postion relative to the start of a file.
-func (m *MdatBox) ReadData(start, size int64) ([]byte, error) {
+// The ReadSeeker is used for lazily loaded mdat case.
+func (m *MdatBox) ReadData(start, size int64, rs io.ReadSeeker) ([]byte, error) {
 	// The Mdat box was decoded lazily
 	if m.decLazyDataSize > 0 {
-		if m.readSeeker == nil {
+		if rs == nil {
 			return nil, errors.New("lazy mdat mode - expects non-nil readseeker to read data")
 		}
 
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		_, err := m.readSeeker.Seek(start, io.SeekStart)
+		_, err := rs.Seek(start, io.SeekStart)
 		if err != nil {
 			return nil, fmt.Errorf("lazy mdat mode - unable to seek to %d", start)
 		}
 
 		buf := make([]byte, size)
-		n, err := m.readSeeker.Read(buf)
+		n, err := rs.Read(buf)
 		if err != nil {
 			return nil, err
 		}
@@ -138,5 +124,36 @@ func (m *MdatBox) ReadData(start, size int64) ([]byte, error) {
 		return nil, fmt.Errorf("normal mdat mode - invalid range provided")
 	}
 	return m.Data[offsetInMdatData : offsetInMdatData+uint64(size)], nil
+
+}
+
+// SeekAndCopyData - seek data in mdat and copy to w.
+// The ReadSeeker is used for lazily loaded mdat case.
+func (m *MdatBox) SeekAndCopyData(start, size int64, rs io.ReadSeeker, w io.Writer) (nrWritten int64, err error) {
+	// The Mdat box was decoded lazily
+	if m.decLazyDataSize == 0 {
+		if rs == nil {
+			return 0, errors.New("lazy mdat mode - expects non-nil readseeker to read data")
+		}
+
+		_, err := rs.Seek(start, io.SeekStart)
+		if err != nil {
+			return 0, fmt.Errorf("lazy mdat mode - unable to seek to %d", start)
+		}
+		return io.CopyN(w, rs, size)
+	}
+
+	// Otherwise, all Mdat data is in memory
+	mdatPayloadStart := m.PayloadAbsoluteOffset()
+	offsetInMdatData := uint64(start) - mdatPayloadStart
+	endIndexInMdatData := offsetInMdatData + uint64(size)
+
+	// validate if indexes are valid to avoid panics
+	if uint64(start) < mdatPayloadStart || endIndexInMdatData >= uint64(len(m.Data)) {
+		return 0, fmt.Errorf("normal mdat mode - invalid range provided")
+	}
+	var n int
+	n, err = w.Write(m.Data[offsetInMdatData : offsetInMdatData+uint64(size)])
+	return int64(n), err
 
 }

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -127,11 +127,11 @@ func (m *MdatBox) ReadData(start, size int64, rs io.ReadSeeker) ([]byte, error) 
 
 }
 
-// SeekAndCopyData - seek data in mdat and copy to w.
+// CopyData - copy data range from mdat to w.
 // The ReadSeeker is used for lazily loaded mdat case.
-func (m *MdatBox) SeekAndCopyData(start, size int64, rs io.ReadSeeker, w io.Writer) (nrWritten int64, err error) {
+func (m *MdatBox) CopyData(start, size int64, rs io.ReadSeeker, w io.Writer) (nrWritten int64, err error) {
 	// The Mdat box was decoded lazily
-	if m.decLazyDataSize == 0 {
+	if m.decLazyDataSize > 0 {
 		if rs == nil {
 			return 0, errors.New("lazy mdat mode - expects non-nil readseeker to read data")
 		}

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -2,7 +2,6 @@ package mp4
 
 import (
 	"bytes"
-	"sync"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -88,7 +87,7 @@ func TestReadData_NormalMode(t *testing.T) {
 		Data:     []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
 	}
 
-	data, err := mdat.ReadData(9, 5)
+	data, err := mdat.ReadData(9, 5, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -115,16 +114,14 @@ func TestReadData_LazyMdatMode(t *testing.T) {
 		t.Error(err)
 	}
 
-	// test ReadData with provided ReadSeeker
 	lazyMdat := &MdatBox{
 		StartPos:        0,
-		decLazyDataSize: 7,
-		mu:              &sync.Mutex{},
+		decLazyDataSize: 6,
 	}
 
+	// test ReadData with provided ReadSeeker
 	readSeeker := bytes.NewReader(buf.Bytes())
-	lazyMdat.setReadSeeker(readSeeker)
-	data, err := lazyMdat.ReadData(9, 5)
+	data, err := lazyMdat.ReadData(9, 5, readSeeker)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
I think that this explicit passing of a ReadSeeker is better and one can also get rid of the mutex.
Also added a function to copy mdat data directly to an io.Writer.